### PR TITLE
The "getArtistTracks" method and the "pageSize" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ This library provides following methods:
 #### Tracks
 
 - getTrack
+- getArtistTracks
 - getSingleTrack
 - getTrackSupplement
 - getTrackDownloadInfo

--- a/src/YMApi.ts
+++ b/src/YMApi.ts
@@ -32,6 +32,7 @@ import {
   FilledArtist,
   Artist,
   ArtistId,
+  ArtistTracksResponse,
 } from "./types";
 
 export default class YMApi {
@@ -134,6 +135,7 @@ export default class YMApi {
   search(query: string, options: SearchOptions = {}): Promise<SearchResponse> {
     const type = !options.type ? "all" : options.type;
     const page = String(!options.page ? 0 : options.page);
+    const pageSize = String(!options.page ? 0 : options.pageSize);
     const nococrrect = String(
       options.nococrrect == null ? false : options.nococrrect
     );
@@ -144,6 +146,7 @@ export default class YMApi {
         type,
         text: query,
         page,
+        pageSize,
         nococrrect,
       });
 
@@ -482,5 +485,26 @@ export default class YMApi {
       .addHeaders(this.getAuthHeader());
 
     return this.httpClient.post(request) as Promise<Array<Artist>>;
+  }
+
+  /**
+   * GET: /artists/[artist_id]/tracks
+   * Get tracks by artist id
+   */
+  getArtistTracks(
+    artistId: ArtistId,
+    options: SearchOptions = {}
+  ): Promise<ArtistTracksResponse> {
+    const page = String(!options.page ? 0 : options.page);
+    const pageSize = String(!options.pageSize ? 0 : options.pageSize);
+    const request = apiRequest()
+      .setPath(`/artists/${artistId}/tracks`)
+      .addHeaders(this.getAuthHeader())
+      .setQuery({
+        page,
+        pageSize,
+      });
+
+    return this.httpClient.get(request) as Promise<ArtistTracksResponse>;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -366,6 +366,11 @@ export type SearchResponse = {
   };
 };
 
+export type ArtistTracksResponse = {
+  pager: Pager;
+  tracks: Array<Track>;
+};
+
 export type SearchAllResponse = Required<SearchResponse>;
 export type SearchArtistsResponse = Required<
   Omit<Omit<SearchResponse, "albums">, "tracks">
@@ -484,6 +489,13 @@ export type SearchOptions = {
   type?: SearchType;
   page?: number;
   nococrrect?: boolean;
+  pageSize?: number;
 };
 
 export type ConcreteSearchOptions = Omit<SearchOptions, "type">;
+
+export type Pager = {
+  page: number;
+  perPage: number;
+  total: number;
+};


### PR DESCRIPTION
Added a method for getting tracks by artist ID and the ability to configure the number of results on the page.
The "getArtistTracks" method returns the promise data, which is described in the documentation [https://yandex-music.readthedocs.io/ru/latest/yandex_music.artist.artist_tracks.html#yandex-music-artisttracks](url)