### PR TITLE
Step to informativity

### DIFF
--- a/src/ApiError.ts
+++ b/src/ApiError.ts
@@ -1,0 +1,9 @@
+class ApiError extends Error {
+	constructor(error:{name:string;message:string}) {
+		super();
+		this.name = error.name || "unknown";
+		this.message = error.message || "An unknown error has occurred";
+	}
+}
+
+export default ApiError;

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -5,6 +5,7 @@ import {
   Response,
   RequestInterface,
 } from "./types";
+import ApiError from "./ApiError";
 
 export default class HttpClient implements HttpClientInterface {
   async _sendRequestAxios(
@@ -31,13 +32,12 @@ export default class HttpClient implements HttpClientInterface {
       } else {
         return data;
       }
-    } catch (e) {
-      console.error({
-        status: e.response.status,
-        headers: e.response.headers,
-        data: e.response.data,
-      });
-      throw new Error(`Request failed: ${e.message}`);
+    } catch (e:any) {
+	  if (e.response.data?.error) {
+		throw new ApiError(e.response.data.error)
+	  } else {
+		throw new Error(`Request failed: ${e.message}`);
+	  }
     }
   }
 


### PR DESCRIPTION
Now Yandex errors can be used in exception handlers. For example, you can get the revision number from error message. 

(Also removed useless console.error)